### PR TITLE
This commit fixes a critical bug where sending a message in the new c…

### DIFF
--- a/ai_handler.js
+++ b/ai_handler.js
@@ -2,11 +2,20 @@ let conversationHistory = [];
 const apiKey = 'AIzaSyAKTRThK4t2AVsrTiwJjnEEY-bdK6UHJho'; // User-provided API Key
 
 document.addEventListener('DOMContentLoaded', () => {
-    const chatForm = document.getElementById('chat-form');
-    if (chatForm) {
+    const sendBtn = document.getElementById('send-chat-btn');
+    const chatInput = document.getElementById('chat-input');
+
+    if (sendBtn && chatInput) {
         // Add welcome message to history on load
         conversationHistory.push({ role: 'assistant', text: 'Здравствуйте! Я ваш юридический ИИ-консультант. Опишите, какие изменения вы хотите внести в договор, и мы вместе подготовим документ.' });
-        chatForm.addEventListener('submit', handleChatSubmit);
+
+        sendBtn.addEventListener('click', handleSendMessage);
+        chatInput.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault(); // Prevent new line
+                handleSendMessage();
+            }
+        });
     }
     renderChatHistory();
 });
@@ -34,8 +43,7 @@ function renderChatHistory() {
     chatHistoryDiv.scrollTop = chatHistoryDiv.scrollHeight;
 }
 
-async function handleChatSubmit(event) {
-    event.preventDefault();
+async function handleSendMessage() {
     const chatInput = document.getElementById('chat-input');
     const sendBtn = document.getElementById('send-chat-btn');
     const finalDocOutput = document.getElementById('final-document-output');

--- a/index.html
+++ b/index.html
@@ -81,10 +81,10 @@
                         </div>
                     </div>
                     <div class="k-card-footer">
-                        <form id="chat-form" class="chat-input-form">
+                        <div class="chat-input-form">
                             <textarea id="chat-input" class="k-textarea" placeholder="Введите ваш запрос..." rows="2"></textarea>
-                            <button type="submit" class="k-button" id="send-chat-btn">Отправить</button>
-                        </form>
+                            <button type="button" class="k-button" id="send-chat-btn">Отправить</button>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
…hat interface caused a full page reload, resetting the view to the 'Old Design' tab.

The fix involves two main changes:
1.  **HTML:** The `<form>` element wrapping the chat input was removed, and the send button's type was explicitly set to `type="button"`. This prevents the browser's default form submission behavior.
2.  **JavaScript:** The event handling logic in `ai_handler.js` was updated to listen for `click` events on the send button and `keydown` events (for the 'Enter' key) on the textarea, rather than a form submission event.

This ensures that sending a message is handled purely by JavaScript without triggering a page navigation, providing the expected user experience for a chat application.