### PR TITLE
fix: Correct Gemini model name in API call

### DIFF
--- a/script.js
+++ b/script.js
@@ -226,7 +226,7 @@ async function handleSendMessage() {
             systemInstruction: { parts: [{ text: systemPrompt }] },
             generationConfig: { temperature: 0.7, topK: 1, topP: 1, maxOutputTokens: 4096 }
         };
-        const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
+        const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`;
         const response = await fetch(apiUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
The AI assistant was not responding to user queries because the API call was being made to an incorrect model name (`gemini-2.0-flash`). This change corrects the model name to `gemini-1.5-flash` to resolve the issue.